### PR TITLE
Implement free repo website excluding Riley

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Riley Script Kitty Repository
+
+This repository contains a simple web server that serves a free code repository to everyone except a user named Riley.
+
+## Usage
+
+1. Ensure you have Node.js installed.
+2. Run `node index.js` to start the server.
+3. Visit `http://localhost:3000/?user=YourName` in your browser.
+   - Replace `YourName` with any name except `Riley` to access the repository.
+   - If `user=Riley`, the server returns an access denied page.
+
+The website is 100% free for all users except Riley.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,52 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const publicDir = path.join(__dirname, 'public');
+
+function serveFile(res, filePath, contentType = 'text/html') {
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Server error');
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url, true);
+  const user = parsed.query.user || '';
+
+  if (user.toLowerCase() === 'riley') {
+    return serveFile(res, path.join(publicDir, 'blocked.html'));
+  }
+
+  let filePath = path.join(publicDir, parsed.pathname === '/' ? 'index.html' : parsed.pathname);
+
+  if (!filePath.startsWith(publicDir)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = ext === '.css' ? 'text/css' : ext === '.js' ? 'application/javascript' : 'text/html';
+
+  fs.access(filePath, fs.constants.F_OK, (err) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not found');
+    } else {
+      serveFile(res, filePath, contentType);
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "rileyscriptkitty",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/blocked.html
+++ b/public/blocked.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Access Denied</title>
+</head>
+<body>
+  <h1>Sorry Riley</h1>
+  <p>You are not allowed to access this free repository.</p>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Free Code Repository</title>
+</head>
+<body>
+  <h1>Welcome to the Free Code Repository</h1>
+  <p>This site is completely free for everyone. Unless your name is Riley.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple Node server to host a free code repository
- serve an "access denied" page when `user=Riley`
- document usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686eca014dac8332aff87744e2c9196d